### PR TITLE
Fix overlay and perfomance issues

### DIFF
--- a/src/client/java/com/criticalrange/client/VulkanModExtraClient.java
+++ b/src/client/java/com/criticalrange/client/VulkanModExtraClient.java
@@ -106,12 +106,7 @@ public class VulkanModExtraClient implements ClientModInitializer {
      */
     public static void onHudRender(DrawContext drawContext, float partialTicks) {
         if (instance != null) {
-            // Render features HUD
-            if (instance.fpsDisplayFeature != null) {
-                instance.fpsDisplayFeature.render(drawContext, partialTicks);
-            }
-            
-            // Render legacy HUD
+            // Render overlay via HUD only to avoid duplicate FPS text
             if (instance.hud != null) {
                 instance.hud.onHudRender(drawContext, partialTicks);
             }

--- a/src/client/java/com/criticalrange/client/VulkanModExtraHud.java
+++ b/src/client/java/com/criticalrange/client/VulkanModExtraHud.java
@@ -71,6 +71,11 @@ public class VulkanModExtraHud {
     private void renderOverlay(DrawContext drawContext) {
         var config = VulkanModExtra.CONFIG.extraSettings;
 
+        // if none is true: nothing to render
+        if (!config.showFps && !config.showCoords) {
+            return;
+        }
+
         int screenWidth = minecraft.getWindow().getScaledWidth();
         int screenHeight = minecraft.getWindow().getScaledHeight();
 

--- a/src/client/java/com/criticalrange/features/fps/FPSDisplayFeature.java
+++ b/src/client/java/com/criticalrange/features/fps/FPSDisplayFeature.java
@@ -79,7 +79,10 @@ public class FPSDisplayFeature extends BaseFeature {
         StringBuilder text = new StringBuilder();
         text.append("FPS: ").append(fpsCounter.getCurrentFPS());
 
-        if (config.extraSettings.showFPSDetails && showDetails) {
+        // Only show extended stats in full or detailed modes
+        var mode = config.extraSettings.fpsDisplayMode;
+        boolean showExtended = (mode == VulkanModExtraConfig.FPSDisplayMode.EXTENDED || mode == VulkanModExtraConfig.FPSDisplayMode.DETAILED);
+        if (showExtended && config.extraSettings.showFPSDetails && showDetails) {
             text.append(" (")
                 .append("avg: ").append(fpsCounter.getAverageFPS())
                 .append(", min: ").append(fpsCounter.getMinFPS())


### PR DESCRIPTION
**What I fixed:**

1. Fixed duplicate rendering that made the first digit of "FPS: " in the HUD to appear overlapped
2. Corrected the "Simple" FPS Display Mode, which was incorrectly showing extra stats (avg/min/max), this should now only appear in full/detailed modes.
3. Fixed the overlay’s draw path running even when both fps and coordinates were disabled

I have been tested all fixes and are working correctly