### PR TITLE
Crash in Video Settings menu Fix (Android 14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 This Fork of VulkanMod Extra intends to increase function of VulkanMod Extra on Android devices
 
 Current state:
-- opening video options no longer crashes the game
-- video options do not display -> mod still outputs to console, shows signs of function
+- opening video options no longer crashes the game 
+- appears fixed
 
 # VulkanMod Extra
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# VulkanMod Extra Android Fix
+This Fork of VulkanMod Extra intends to increase function of VulkanMod Extra on Android devices
+
+Current state:
+- opening video options no longer crashes the game
+- video options do not display -> mod still outputs to console, shows signs of function
+
 # VulkanMod Extra
 
 [![Modrinth Version](https://img.shields.io/modrinth/v/vulkanmod-extra?logo=modrinth&label=modrinth&color=00AF5C)](https://modrinth.com/mod/vulkanmod-extra)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-# VulkanMod Extra Android Fix
-This Fork of VulkanMod Extra intends to increase function of VulkanMod Extra on Android devices
-
-Current state:
-- opening video options no longer crashes the game 
-- appears fixed
-
 # VulkanMod Extra
 
 [![Modrinth Version](https://img.shields.io/modrinth/v/vulkanmod-extra?logo=modrinth&label=modrinth&color=00AF5C)](https://modrinth.com/mod/vulkanmod-extra)

--- a/fabric-1.21.1/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
+++ b/fabric-1.21.1/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
@@ -71,7 +71,7 @@ public class MixinVulkanModMonitorSelection {
                             } else {
                                 monitorHandles.add(0L); // Fallback to primary
                             }
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             monitorHandles.add(0L); // Fallback to primary
                         }
                     }
@@ -90,7 +90,7 @@ public class MixinVulkanModMonitorSelection {
                     selectedMonitorIndex = 0;
                 }
                 
-            } catch (Exception e) {
+            } catch (Exception | LinkageError e) {
                 // Fallback to GLFW if OSHI fails
                 initializeMonitorsWithGLFW();
             }
@@ -119,7 +119,7 @@ public class MixinVulkanModMonitorSelection {
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Final fallback
             availableMonitors.add("Primary");
             monitorHandles.add(0L);
@@ -179,7 +179,7 @@ public class MixinVulkanModMonitorSelection {
             
             // Also inject video tooltips into the final blocks
             injectVideoTooltips(finalBlocks);
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Log error but continue with original blocks
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to inject monitor selection into video options: {}", e.getMessage());
@@ -209,7 +209,7 @@ public class MixinVulkanModMonitorSelection {
             }
             
             return false;
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to check block for resolution options: {}", e.getMessage());
             }
@@ -244,7 +244,7 @@ public class MixinVulkanModMonitorSelection {
                 newOptions.toArray(new Option<?>[0])
             );
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to add monitor selection to existing block: {}", e.getMessage());
             }
@@ -283,14 +283,14 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod-extra.option.video.monitorSelection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
             
             return monitorOption;
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection option: {}", e.getMessage());
             }
@@ -331,7 +331,7 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod.options.video.monitor_selection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
@@ -343,7 +343,7 @@ public class MixinVulkanModMonitorSelection {
                 options.toArray(new Option<?>[0])
             );
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection block: {}", e.getMessage());
             }
@@ -390,7 +390,7 @@ public class MixinVulkanModMonitorSelection {
             
             return option;
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create cycling option: {}", e.getMessage());
             }
@@ -431,21 +431,21 @@ public class MixinVulkanModMonitorSelection {
                             java.lang.reflect.Field selectedVideoModeField = VideoModeManager.class.getDeclaredField("selectedVideoMode");
                             selectedVideoModeField.setAccessible(true);
                             selectedVideoModeField.set(null, currentMode);
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update selected video mode: {}", e.getMessage());
                             }
                         }
                         
                         
-                    } catch (Exception e) {
+                    } catch (Exception | LinkageError e) {
                         if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                             com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video mode sets: {}", e.getMessage());
                         }
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video modes for selected monitor: {}", e.getMessage());
             }
@@ -532,7 +532,7 @@ public class MixinVulkanModMonitorSelection {
             }
 
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to inject video tooltips", e);
             }
@@ -563,13 +563,13 @@ public class MixinVulkanModMonitorSelection {
                     try {
                         Text tooltip = Text.translatable(tooltipKey);
                         option.setTooltip(tooltip);
-                    } catch (Exception e) {
+                    } catch (Exception | LinkageError e) {
                         // Silently continue on failure
                     }
                 }
             }
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.warn("Failed to inject tooltips into option block", e);
             }

--- a/fabric-1.21.2/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
+++ b/fabric-1.21.2/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
@@ -71,7 +71,7 @@ public class MixinVulkanModMonitorSelection {
                             } else {
                                 monitorHandles.add(0L); // Fallback to primary
                             }
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             monitorHandles.add(0L); // Fallback to primary
                         }
                     }
@@ -90,7 +90,7 @@ public class MixinVulkanModMonitorSelection {
                     selectedMonitorIndex = 0;
                 }
                 
-            } catch (Exception e) {
+            } catch (Exception | LinkageError e) {
                 // Fallback to GLFW if OSHI fails
                 initializeMonitorsWithGLFW();
             }
@@ -119,7 +119,7 @@ public class MixinVulkanModMonitorSelection {
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Final fallback
             availableMonitors.add("Primary");
             monitorHandles.add(0L);
@@ -179,7 +179,7 @@ public class MixinVulkanModMonitorSelection {
             
             // Also inject video tooltips into the final blocks
             injectVideoTooltips(finalBlocks);
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Log error but continue with original blocks
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to inject monitor selection into video options: {}", e.getMessage());
@@ -209,7 +209,7 @@ public class MixinVulkanModMonitorSelection {
             }
             
             return false;
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to check block for resolution options: {}", e.getMessage());
             }
@@ -244,7 +244,7 @@ public class MixinVulkanModMonitorSelection {
                 newOptions.toArray(new Option<?>[0])
             );
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to add monitor selection to existing block: {}", e.getMessage());
             }
@@ -283,14 +283,14 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod-extra.option.video.monitorSelection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
             
             return monitorOption;
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection option: {}", e.getMessage());
             }
@@ -331,7 +331,7 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod.options.video.monitor_selection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
@@ -343,7 +343,7 @@ public class MixinVulkanModMonitorSelection {
                 options.toArray(new Option<?>[0])
             );
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection block: {}", e.getMessage());
             }
@@ -390,7 +390,7 @@ public class MixinVulkanModMonitorSelection {
             
             return option;
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create cycling option: {}", e.getMessage());
             }
@@ -431,21 +431,21 @@ public class MixinVulkanModMonitorSelection {
                             java.lang.reflect.Field selectedVideoModeField = VideoModeManager.class.getDeclaredField("selectedVideoMode");
                             selectedVideoModeField.setAccessible(true);
                             selectedVideoModeField.set(null, currentMode);
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update selected video mode: {}", e.getMessage());
                             }
                         }
                         
                         
-                    } catch (Exception e) {
+                    } catch (Exception | LinkageError e) {
                         if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                             com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video mode sets: {}", e.getMessage());
                         }
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video modes for selected monitor: {}", e.getMessage());
             }
@@ -532,7 +532,7 @@ public class MixinVulkanModMonitorSelection {
             }
 
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Silently continue on failure
         }
     }
@@ -562,14 +562,14 @@ public class MixinVulkanModMonitorSelection {
                         try {
                             Text tooltip = Text.translatable(tooltipKey);
                             option.setTooltip(tooltip);
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             // Silently continue on failure
                         }
                     }
                 }
             }
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.warn("Failed to inject tooltips into option block", e);
             }

--- a/fabric-1.21.3/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
+++ b/fabric-1.21.3/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
@@ -71,7 +71,7 @@ public class MixinVulkanModMonitorSelection {
                             } else {
                                 monitorHandles.add(0L); // Fallback to primary
                             }
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             monitorHandles.add(0L); // Fallback to primary
                         }
                     }
@@ -90,7 +90,7 @@ public class MixinVulkanModMonitorSelection {
                     selectedMonitorIndex = 0;
                 }
                 
-            } catch (Exception e) {
+            } catch (Exception | LinkageError e) {
                 // Fallback to GLFW if OSHI fails
                 initializeMonitorsWithGLFW();
             }
@@ -119,7 +119,7 @@ public class MixinVulkanModMonitorSelection {
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Final fallback
             availableMonitors.add("Primary");
             monitorHandles.add(0L);
@@ -179,7 +179,7 @@ public class MixinVulkanModMonitorSelection {
             
             // Also inject video tooltips into the final blocks
             injectVideoTooltips(finalBlocks);
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Log error but continue with original blocks
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to inject monitor selection into video options: {}", e.getMessage());
@@ -209,7 +209,7 @@ public class MixinVulkanModMonitorSelection {
             }
             
             return false;
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to check block for resolution options: {}", e.getMessage());
             }
@@ -244,7 +244,7 @@ public class MixinVulkanModMonitorSelection {
                 newOptions.toArray(new Option<?>[0])
             );
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to add monitor selection to existing block: {}", e.getMessage());
             }
@@ -283,14 +283,14 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod-extra.option.video.monitorSelection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
             
             return monitorOption;
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection option: {}", e.getMessage());
             }
@@ -331,7 +331,7 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod.options.video.monitor_selection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
@@ -343,7 +343,7 @@ public class MixinVulkanModMonitorSelection {
                 options.toArray(new Option<?>[0])
             );
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection block: {}", e.getMessage());
             }
@@ -390,7 +390,7 @@ public class MixinVulkanModMonitorSelection {
             
             return option;
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create cycling option: {}", e.getMessage());
             }
@@ -431,21 +431,21 @@ public class MixinVulkanModMonitorSelection {
                             java.lang.reflect.Field selectedVideoModeField = VideoModeManager.class.getDeclaredField("selectedVideoMode");
                             selectedVideoModeField.setAccessible(true);
                             selectedVideoModeField.set(null, currentMode);
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update selected video mode: {}", e.getMessage());
                             }
                         }
                         
                         
-                    } catch (Exception e) {
+                    } catch (Exception | LinkageError e) {
                         if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                             com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video mode sets: {}", e.getMessage());
                         }
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video modes for selected monitor: {}", e.getMessage());
             }
@@ -532,7 +532,7 @@ public class MixinVulkanModMonitorSelection {
             }
 
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Silently continue on failure
         }
     }
@@ -562,14 +562,14 @@ public class MixinVulkanModMonitorSelection {
                         try {
                             Text tooltip = Text.translatable(tooltipKey);
                             option.setTooltip(tooltip);
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             // Silently continue on failure
                         }
                     }
                 }
             }
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.warn("Failed to inject tooltips into option block", e);
             }

--- a/fabric-1.21.4/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
+++ b/fabric-1.21.4/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
@@ -71,7 +71,7 @@ public class MixinVulkanModMonitorSelection {
                             } else {
                                 monitorHandles.add(0L); // Fallback to primary
                             }
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             monitorHandles.add(0L); // Fallback to primary
                         }
                     }
@@ -90,7 +90,7 @@ public class MixinVulkanModMonitorSelection {
                     selectedMonitorIndex = 0;
                 }
                 
-            } catch (Exception e) {
+            } catch (Exception | LinkageError e) {
                 // Fallback to GLFW if OSHI fails
                 initializeMonitorsWithGLFW();
             }
@@ -119,7 +119,7 @@ public class MixinVulkanModMonitorSelection {
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Final fallback
             availableMonitors.add("Primary");
             monitorHandles.add(0L);
@@ -179,7 +179,7 @@ public class MixinVulkanModMonitorSelection {
             
             // Also inject video tooltips into the final blocks
             injectVideoTooltips(finalBlocks);
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Log error but continue with original blocks
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to inject monitor selection into video options: {}", e.getMessage());
@@ -209,7 +209,7 @@ public class MixinVulkanModMonitorSelection {
             }
             
             return false;
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to check block for resolution options: {}", e.getMessage());
             }
@@ -244,7 +244,7 @@ public class MixinVulkanModMonitorSelection {
                 newOptions.toArray(new Option<?>[0])
             );
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to add monitor selection to existing block: {}", e.getMessage());
             }
@@ -283,14 +283,14 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod-extra.option.video.monitorSelection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
             
             return monitorOption;
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection option: {}", e.getMessage());
             }
@@ -331,7 +331,7 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod.options.video.monitor_selection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
@@ -343,7 +343,7 @@ public class MixinVulkanModMonitorSelection {
                 options.toArray(new Option<?>[0])
             );
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection block: {}", e.getMessage());
             }
@@ -390,7 +390,7 @@ public class MixinVulkanModMonitorSelection {
             
             return option;
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create cycling option: {}", e.getMessage());
             }
@@ -431,21 +431,21 @@ public class MixinVulkanModMonitorSelection {
                             java.lang.reflect.Field selectedVideoModeField = VideoModeManager.class.getDeclaredField("selectedVideoMode");
                             selectedVideoModeField.setAccessible(true);
                             selectedVideoModeField.set(null, currentMode);
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update selected video mode: {}", e.getMessage());
                             }
                         }
                         
                         
-                    } catch (Exception e) {
+                    } catch (Exception | LinkageError e) {
                         if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                             com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video mode sets: {}", e.getMessage());
                         }
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video modes for selected monitor: {}", e.getMessage());
             }
@@ -532,7 +532,7 @@ public class MixinVulkanModMonitorSelection {
             }
 
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Silently continue on failure
         }
     }
@@ -562,14 +562,14 @@ public class MixinVulkanModMonitorSelection {
                         try {
                             Text tooltip = Text.translatable(tooltipKey);
                             option.setTooltip(tooltip);
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             // Silently continue on failure
                         }
                     }
                 }
             }
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.warn("Failed to inject tooltips into option block", e);
             }

--- a/fabric-1.21.5/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
+++ b/fabric-1.21.5/src/main/java/com/criticalrange/mixins/vulkanmod/MixinVulkanModMonitorSelection.java
@@ -71,7 +71,7 @@ public class MixinVulkanModMonitorSelection {
                             } else {
                                 monitorHandles.add(0L); // Fallback to primary
                             }
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             monitorHandles.add(0L); // Fallback to primary
                         }
                     }
@@ -90,7 +90,7 @@ public class MixinVulkanModMonitorSelection {
                     selectedMonitorIndex = 0;
                 }
                 
-            } catch (Exception e) {
+            } catch (Exception | LinkageError e) {
                 // Fallback to GLFW if OSHI fails
                 initializeMonitorsWithGLFW();
             }
@@ -119,7 +119,7 @@ public class MixinVulkanModMonitorSelection {
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Final fallback
             availableMonitors.add("Primary");
             monitorHandles.add(0L);
@@ -179,7 +179,7 @@ public class MixinVulkanModMonitorSelection {
             
             // Also inject video tooltips into the final blocks
             injectVideoTooltips(finalBlocks);
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Log error but continue with original blocks
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to inject monitor selection into video options: {}", e.getMessage());
@@ -209,7 +209,7 @@ public class MixinVulkanModMonitorSelection {
             }
             
             return false;
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to check block for resolution options: {}", e.getMessage());
             }
@@ -244,7 +244,7 @@ public class MixinVulkanModMonitorSelection {
                 newOptions.toArray(new Option<?>[0])
             );
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to add monitor selection to existing block: {}", e.getMessage());
             }
@@ -283,14 +283,14 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod-extra.option.video.monitorSelection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
             
             return monitorOption;
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection option: {}", e.getMessage());
             }
@@ -331,7 +331,7 @@ public class MixinVulkanModMonitorSelection {
                 try {
                     Text tooltip = Text.translatable("vulkanmod.options.video.monitor_selection.tooltip");
                     monitorOption.setTooltip(tooltip);
-                } catch (Exception e) {
+                } catch (Exception | LinkageError e) {
                     // Silently continue if tooltip fails
                 }
             }
@@ -343,7 +343,7 @@ public class MixinVulkanModMonitorSelection {
                 options.toArray(new Option<?>[0])
             );
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create monitor selection block: {}", e.getMessage());
             }
@@ -390,7 +390,7 @@ public class MixinVulkanModMonitorSelection {
             
             return option;
             
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to create cycling option: {}", e.getMessage());
             }
@@ -431,21 +431,21 @@ public class MixinVulkanModMonitorSelection {
                             java.lang.reflect.Field selectedVideoModeField = VideoModeManager.class.getDeclaredField("selectedVideoMode");
                             selectedVideoModeField.setAccessible(true);
                             selectedVideoModeField.set(null, currentMode);
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update selected video mode: {}", e.getMessage());
                             }
                         }
                         
                         
-                    } catch (Exception e) {
+                    } catch (Exception | LinkageError e) {
                         if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                             com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video mode sets: {}", e.getMessage());
                         }
                     }
                 }
             }
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.error("Failed to update video modes for selected monitor: {}", e.getMessage());
             }
@@ -532,7 +532,7 @@ public class MixinVulkanModMonitorSelection {
             }
 
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             // Silently continue on failure
         }
     }
@@ -562,14 +562,14 @@ public class MixinVulkanModMonitorSelection {
                         try {
                             Text tooltip = Text.translatable(tooltipKey);
                             option.setTooltip(tooltip);
-                        } catch (Exception e) {
+                        } catch (Exception | LinkageError e) {
                             // Silently continue on failure
                         }
                     }
                 }
             }
 
-        } catch (Exception e) {
+        } catch (Exception | LinkageError e) {
             if (com.criticalrange.VulkanModExtra.LOGGER != null) {
                 com.criticalrange.VulkanModExtra.LOGGER.warn("Failed to inject tooltips into option block", e);
             }


### PR DESCRIPTION
What i Fixed:

- game crash (NoSuchMethodError) under Zalith Launcher (Android 14) no longer occurs when opening the video settings menu
- changed exception catches in MixinVulkanModMonitorSelection.java to also catch NoSuchMethodError (child of LinkageError)
- LinkageError was chosen in order to also catch similar errors (NoSuchFieldError, NoClassDefFoundError, etc.) in anticipation of future changes